### PR TITLE
Prevent words from spliting into two lines

### DIFF
--- a/src/adjustStr.c
+++ b/src/adjustStr.c
@@ -69,6 +69,16 @@ void adjustStr(char *p[], int len, char *storage[]) {
                 maxlen_google = nowlen;
             //printf("maxlen_google=%d\n", maxlen_google);
 
+            /* 防止单词被割裂为两行(上一行末尾 下一行开头) */ 
+            if (nowlen == len && isalnum(p[i][j]) && isalnum(p[i][j+1]))
+            {
+                int goback = 0;
+                while (isalnum(p[i][j--]))
+                {
+                    storage[i][k - goback++] = ' ';
+                }
+            }
+
             if ( nowlen == len ) {
                 storage[i][++k] = '\n';
                 lines_google++;


### PR DESCRIPTION
> 英文解释中经常出现一个问题 ，一个单词被割裂为两行（上一行末尾 下一行开头），阅读起来不方便
> ![image](https://user-images.githubusercontent.com/13901512/64482446-ad520500-d224-11e9-965f-8e0e69a4730b.png)

修改后的效果：
![image](https://user-images.githubusercontent.com/13901512/64502704-266f5c00-d2fa-11e9-9bd6-22df6dab36f6.png)
